### PR TITLE
Add repository processing endpoint and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,43 @@ curl -X POST http://127.0.0.1:5000/api/login \
 { "message": "Login successful." }
 ```
 
+### Record Repository Processing Request
+
+```bash
+POST /api/process_repo
+```
+
+**Request Body**
+
+```json
+{
+  "user_email": "user@example.com",
+  "github_repo": "https://github.com/org/repo",
+  "timestamp": "2024-06-12T15:32:00Z"
+}
+```
+
+- **Description**: Records a user's request to process a specific GitHub repository and stores it in the `user_repo_requests` collection in MongoDB.
+- **Response**: `201 Created` on success with a confirmation message. Returns `400` if required fields are missing or the timestamp is malformed.
+
+**Example**
+
+```bash
+curl -X POST http://127.0.0.1:5000/api/process_repo \
+  -H "Content-Type: application/json" \
+  -d '{
+        "user_email": "user@example.com",
+        "github_repo": "https://github.com/org/repo",
+        "timestamp": "2024-06-12T15:32:00Z"
+      }'
+```
+
+**Successful Response**
+
+```json
+{ "message": "Repository request recorded." }
+```
+
 ### Fetching GitHub Repository Data
 
 ```bash

--- a/docs/process_repo_endpoint.md
+++ b/docs/process_repo_endpoint.md
@@ -1,0 +1,34 @@
+# `/api/process_repo` Endpoint
+
+This endpoint records when a user asks the system to process a GitHub repository.
+
+- **URL**: `/api/process_repo`
+- **Method**: `POST`
+- **Payload**: JSON object containing:
+  - `user_email` (string) – Email address of the requester.
+  - `github_repo` (string) – URL or identifier of the repository to process.
+  - `timestamp` (string) – Time of the request in ISO‑8601 format (e.g. `2024-06-12T15:32:00Z`).
+- **Success Response**: `201 Created` with `{"message": "Repository request recorded."}`
+- **Error Responses**:
+  - `400 Bad Request` – Missing required fields.
+  - `500 Internal Server Error` – Database insertion failed.
+
+## Example
+
+```bash
+curl -X POST http://127.0.0.1:5000/api/process_repo \
+  -H "Content-Type: application/json" \
+  -d '{
+        "user_email": "user@example.com",
+        "github_repo": "https://github.com/org/repo",
+        "timestamp": "2024-06-12T15:32:00Z"
+      }'
+```
+
+### Sample Successful Response
+
+```json
+{ "message": "Repository request recorded." }
+```
+
+The request data is stored in the `user_repo_requests` collection in MongoDB with the `timestamp` saved as a native `datetime` value.

--- a/requirements.txt
+++ b/requirements.txt
@@ -162,3 +162,4 @@ wrapt==1.16.0
 yarg==0.1.9
 yarl==1.15.2
 unidecode==1.3.8
+mongomock==4.1.2

--- a/tests/test_process_repo.py
+++ b/tests/test_process_repo.py
@@ -1,0 +1,40 @@
+import os
+import os
+import sys
+import types
+from datetime import datetime
+import mongomock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+
+def test_process_repo_saves_request(monkeypatch):
+    sys.modules['app.pipeline.orchestrator'] = types.SimpleNamespace(run_pipeline=lambda *a, **k: None)
+    sys.modules['app.pipeline.run_pex'] = types.SimpleNamespace(run_forecast=lambda *a, **k: None)
+    sys.modules['app.pipeline.rust_runner'] = types.SimpleNamespace(run_rust_code=lambda *a, **k: None)
+    sys.modules['app.pipeline.update_pex'] = types.SimpleNamespace(update_pex_generator=lambda *a, **k: None)
+
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client['test-db']
+    monkeypatch.setattr('app.routes.db', mock_db)
+
+    app = create_app()
+    client = app.test_client()
+
+    payload = {
+        'user_email': 'user@example.com',
+        'github_repo': 'https://github.com/org/repo',
+        'timestamp': '2024-06-12T15:32:00Z'
+    }
+
+    res = client.post('/api/process_repo', json=payload)
+    assert res.status_code == 201
+
+    stored = mock_db.user_repo_requests.find_one({'user_email': 'user@example.com'})
+    assert stored is not None
+    assert stored['github_repo'] == payload['github_repo']
+    expected_ts = datetime.fromisoformat(payload['timestamp'].replace('Z', '+00:00'))
+    assert stored['timestamp'] == expected_ts.replace(tzinfo=None)
+


### PR DESCRIPTION
## Summary
- persist `/api/process_repo` requests to MongoDB and validate timestamp format
- document that requests are stored in MongoDB
- add unit test using `mongomock`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6af96f504832ab01d4d67cfa9e163