### PR TITLE
Record registration timestamp for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ POST /api/register
 }
 ```
 
-- **Description**: Creates a new user account. All fields are required. The password is stored securely using a hash.
+- **Description**: Creates a new user account. All fields are required. The password is stored securely using a hash. The server records the registration time in a `registered_at` field.
 - **Response**: `201 Created` on success with a confirmation message. Returns `400` if fields are missing or the email is already registered.
 
 **Example**

--- a/app/routes.py
+++ b/app/routes.py
@@ -65,7 +65,7 @@ def register_user():
         'affiliation': data['affiliation'],
         'password_hash': generate_password_hash(data['password']),
         'referral': data['referral'],
-        'created_at': datetime.utcnow()
+        'registered_at': datetime.utcnow()
     }
 
     db.users.insert_one(user_doc)

--- a/tests/test_register_user.py
+++ b/tests/test_register_user.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from datetime import datetime
+import mongomock
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+
+def test_register_user_saves_timestamp(monkeypatch):
+    # Patch out unused pipeline imports
+    sys.modules['app.pipeline.orchestrator'] = types.SimpleNamespace(run_pipeline=lambda *a, **k: None)
+    sys.modules['app.pipeline.run_pex'] = types.SimpleNamespace(run_forecast=lambda *a, **k: None)
+    sys.modules['app.pipeline.rust_runner'] = types.SimpleNamespace(run_rust_code=lambda *a, **k: None)
+    sys.modules['app.pipeline.update_pex'] = types.SimpleNamespace(update_pex_generator=lambda *a, **k: None)
+
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client['test-db']
+    monkeypatch.setattr('app.routes.db', mock_db)
+
+    app = create_app()
+    client = app.test_client()
+
+    payload = {
+        'full_name': 'Test User',
+        'email': 'test@example.com',
+        'affiliation': 'Test Org',
+        'password': 'secret',
+        'referral': 'Friend'
+    }
+
+    before = datetime.utcnow()
+    res = client.post('/api/register', json=payload)
+    after = datetime.utcnow()
+
+    assert res.status_code == 201
+
+    stored = mock_db.users.find_one({'email': payload['email']})
+    assert stored is not None
+    assert 'registered_at' in stored
+    assert before <= stored['registered_at'] <= after


### PR DESCRIPTION
## Summary
- Track user registration time by storing a `registered_at` timestamp on signup
- Document registration timestamp behavior in the README
- Test that the `/api/register` endpoint persists the server timestamp

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba15c1f5a0832aaa404ca7e88c89c8