### PR TITLE
Add endpoints for user list and repository history

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,62 @@ curl -X POST http://127.0.0.1:5000/api/process_repo \
 { "message": "Repository request recorded." }
 ```
 
+### List Registered Users
+
+```bash
+GET /api/users
+```
+
+- **Description**: Retrieves all registered users. The response includes each user's email and any other metadata stored in the database.
+- **Response**: `200 OK` with a list of user records.
+
+**Example**
+
+```bash
+curl http://127.0.0.1:5000/api/users
+```
+
+**Successful Response**
+
+```json
+{
+  "users": [
+    {
+      "full_name": "Jane Doe",
+      "email": "jane@example.com",
+      "affiliation": "UC Davis",
+      "referral": "Conference Booth",
+      "created_at": "2024-06-12T15:32:00"
+    }
+  ]
+}
+```
+
+### List User's Processed GitHub Repositories
+
+```bash
+GET /api/user_repositories?email=<user_email>
+```
+
+- **Description**: Returns all GitHub repositories processed through the system by the specified user.
+- **Response**: `200 OK` with a list of repository URLs. Returns `400` if the `email` query parameter is missing.
+
+**Example**
+
+```bash
+curl "http://127.0.0.1:5000/api/user_repositories?email=user@example.com"
+```
+
+**Successful Response**
+
+```json
+{
+  "repositories": [
+    "https://github.com/org/repo"
+  ]
+}
+```
+
 ### Fetching GitHub Repository Data
 
 ```bash

--- a/tests/test_user_endpoints.py
+++ b/tests/test_user_endpoints.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import mongomock
+from datetime import datetime
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+
+def setup_mock_db(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client['test-db']
+    monkeypatch.setattr('app.routes.db', mock_db)
+    return mock_db
+
+
+def create_test_client():
+    app = create_app()
+    return app.test_client()
+
+
+def test_get_all_users_returns_users(monkeypatch):
+    mock_db = setup_mock_db(monkeypatch)
+    client = create_test_client()
+
+    mock_db.users.insert_many([
+        {
+            'full_name': 'Jane Doe',
+            'email': 'jane@example.com',
+            'affiliation': 'UC Davis',
+            'referral': 'Conf',
+            'created_at': datetime.utcnow(),
+            'password_hash': 'hash',
+        },
+        {
+            'full_name': 'John Doe',
+            'email': 'john@example.com',
+            'affiliation': 'UC Davis',
+            'referral': 'Friend',
+            'created_at': datetime.utcnow(),
+            'password_hash': 'hash',
+        },
+    ])
+
+    res = client.get('/api/users')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert len(data['users']) == 2
+    emails = {u['email'] for u in data['users']}
+    assert emails == {'jane@example.com', 'john@example.com'}
+    # Ensure password hash is not included
+    assert all('password_hash' not in u for u in data['users'])
+
+
+def test_get_user_repositories_returns_repos(monkeypatch):
+    mock_db = setup_mock_db(monkeypatch)
+    client = create_test_client()
+
+    mock_db.user_repo_requests.insert_many([
+        {
+            'user_email': 'user@example.com',
+            'github_repo': 'https://github.com/org/repo1',
+            'timestamp': datetime.utcnow(),
+        },
+        {
+            'user_email': 'user@example.com',
+            'github_repo': 'https://github.com/org/repo2',
+            'timestamp': datetime.utcnow(),
+        },
+        {
+            'user_email': 'user@example.com',
+            'github_repo': 'https://github.com/org/repo1',
+            'timestamp': datetime.utcnow(),
+        },
+        {
+            'user_email': 'other@example.com',
+            'github_repo': 'https://github.com/org/repo3',
+            'timestamp': datetime.utcnow(),
+        },
+    ])
+
+    res = client.get('/api/user_repositories', query_string={'email': 'user@example.com'})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert set(data['repositories']) == {
+        'https://github.com/org/repo1',
+        'https://github.com/org/repo2',
+    }
+


### PR DESCRIPTION
## Summary
- add `/api/users` to return all registered users with metadata
- add `/api/user_repositories` to list repositories processed by a user
- document new endpoints and provide examples
- add tests for both endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba169328e4832a84cbf2600789e15d