### PR TITLE
Add view tracking endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,33 @@ GET /api/monthly_ranges
 - **Description**: Fetches the monthly range for all available Apache projects.
 
 
+### View Tracking
+
+#### Record a View
+
+```bash
+POST /api/record_view
+```
+- **Description**: Records the current timestamp each time the endpoint is called and stores it in MongoDB.
+- **Example**:
+
+```bash
+curl -X POST http://127.0.0.1:5000/api/record_view
+```
+
+#### Get View Count
+
+```bash
+GET /api/view_count
+```
+- **Description**: Returns the total number of recorded view timestamps.
+- **Example**:
+
+```bash
+curl http://127.0.0.1:5000/api/view_count
+```
+
+
 ### Notes
 - Replace `<project_id>` with the unique identifier for the project.
 - Replace `int:month` with the specific month you want to query.

--- a/app/routes.py
+++ b/app/routes.py
@@ -155,9 +155,39 @@ def get_user_repositories():
         logger.error(f"Error fetching repositories for user {email}: {e}")
         return jsonify({'error': 'Failed to fetch repositories.'}), 500
 
+# ------------------------- View Tracking Endpoints -------------------------
+
+
+@main_routes.route('/api/record_view', methods=['POST'])
+@cross_origin(origin='*')
+def record_view():
+    """Record a view by storing the current timestamp."""
+    timestamp = datetime.utcnow()
+    try:
+        db.view_timestamps.insert_one({'timestamp': timestamp})
+        return jsonify({
+            'message': 'View recorded.',
+            'timestamp': timestamp.isoformat() + 'Z'
+        }), 201
+    except Exception as e:
+        logger.error(f"Error recording view: {e}")
+        return jsonify({'error': 'Failed to record view.'}), 500
+
+
+@main_routes.route('/api/view_count', methods=['GET'])
+@cross_origin(origin='*')
+def get_view_count():
+    """Return the total number of recorded view timestamps."""
+    try:
+        count = db.view_timestamps.count_documents({})
+        return jsonify({'count': count}), 200
+    except Exception as e:
+        logger.error(f"Error retrieving view count: {e}")
+        return jsonify({'error': 'Failed to retrieve view count.'}), 500
+
 # Homepage
 @main_routes.route('/')
-@cross_origin(origin='*') 
+@cross_origin(origin='*')
 def landing_page():
     return "Welcome to the Repository Fetcher for Apache and Eclipse foundations!"
 

--- a/tests/test_view_tracking.py
+++ b/tests/test_view_tracking.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import types
+from datetime import datetime
+import mongomock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+
+def setup_mock_db(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client['test-db']
+    monkeypatch.setattr('app.routes.db', mock_db)
+    return mock_db
+
+
+def create_test_client():
+    app = create_app()
+    return app.test_client()
+
+
+def patch_pipelines():
+    sys.modules['app.pipeline.orchestrator'] = types.SimpleNamespace(run_pipeline=lambda *a, **k: None)
+    sys.modules['app.pipeline.run_pex'] = types.SimpleNamespace(run_forecast=lambda *a, **k: None)
+    sys.modules['app.pipeline.rust_runner'] = types.SimpleNamespace(run_rust_code=lambda *a, **k: None)
+    sys.modules['app.pipeline.update_pex'] = types.SimpleNamespace(update_pex_generator=lambda *a, **k: None)
+
+
+def test_record_view_adds_timestamp(monkeypatch):
+    patch_pipelines()
+    mock_db = setup_mock_db(monkeypatch)
+    client = create_test_client()
+
+    before = datetime.utcnow()
+    res = client.post('/api/record_view')
+    after = datetime.utcnow()
+
+    assert res.status_code == 201
+    data = res.get_json()
+    assert 'timestamp' in data
+
+    stored = mock_db.view_timestamps.find_one()
+    assert stored is not None
+    assert before <= stored['timestamp'] <= after
+
+
+def test_get_view_count_returns_total(monkeypatch):
+    patch_pipelines()
+    mock_db = setup_mock_db(monkeypatch)
+    client = create_test_client()
+
+    mock_db.view_timestamps.insert_many([
+        {'timestamp': datetime.utcnow()},
+        {'timestamp': datetime.utcnow()},
+        {'timestamp': datetime.utcnow()},
+    ])
+
+    res = client.get('/api/view_count')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data['count'] == 3


### PR DESCRIPTION
## Summary
- track views in MongoDB via `/api/record_view`
- expose `/api/view_count` to report total view records
- document view tracking endpoints with usage examples
- add tests for new endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba7e822bb4832a959305a3f03f5717