### PR TITLE
Add login/logout tracking endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,68 @@ curl -X POST http://127.0.0.1:5000/api/login \
 { "message": "Login successful." }
 ```
 
+#### Track User Login
+
+```bash
+POST /api/track_login
+```
+
+**Request Body**
+
+```json
+{
+  "user_email": "jane@example.com"
+}
+```
+
+- **Description**: Records when a user logs in by storing their email and the current server timestamp in the `login_tracking` collection.
+- **Response**: `201 Created` on success with a confirmation message. Returns `400` if `user_email` is missing.
+
+**Example**
+
+```bash
+curl -X POST http://127.0.0.1:5000/api/track_login \
+  -H "Content-Type: application/json" \
+  -d '{"user_email": "jane@example.com"}'
+```
+
+**Successful Response**
+
+```json
+{ "message": "Login tracked." }
+```
+
+#### Track User Logout
+
+```bash
+POST /api/track_logout
+```
+
+**Request Body**
+
+```json
+{
+  "user_email": "jane@example.com"
+}
+```
+
+- **Description**: Records when a user logs out by storing their email and the current server timestamp in the `logout_tracking` collection.
+- **Response**: `201 Created` on success with a confirmation message. Returns `400` if `user_email` is missing.
+
+**Example**
+
+```bash
+curl -X POST http://127.0.0.1:5000/api/track_logout \
+  -H "Content-Type: application/json" \
+  -d '{"user_email": "jane@example.com"}'
+```
+
+**Successful Response**
+
+```json
+{ "message": "Logout tracked." }
+```
+
 ### Record Repository Processing Request
 
 ```bash

--- a/app/routes.py
+++ b/app/routes.py
@@ -90,6 +90,50 @@ def login_user():
     return jsonify({'message': 'Login successful.'}), 200
 
 
+@main_routes.route('/api/track_login', methods=['POST'])
+@cross_origin(origin='*')
+def track_login():
+    """Record a user's login event."""
+    data = request.get_json(silent=True) or {}
+    user_email = data.get('user_email')
+    if not user_email:
+        return jsonify({'error': 'user_email is required.'}), 400
+
+    record = {
+        'user_email': user_email,
+        'timestamp': datetime.utcnow()
+    }
+
+    try:
+        db.login_tracking.insert_one(record)
+        return jsonify({'message': 'Login tracked.'}), 201
+    except Exception as e:
+        logger.error(f"Error recording login for {user_email}: {e}")
+        return jsonify({'error': 'Failed to track login.'}), 500
+
+
+@main_routes.route('/api/track_logout', methods=['POST'])
+@cross_origin(origin='*')
+def track_logout():
+    """Record a user's logout event."""
+    data = request.get_json(silent=True) or {}
+    user_email = data.get('user_email')
+    if not user_email:
+        return jsonify({'error': 'user_email is required.'}), 400
+
+    record = {
+        'user_email': user_email,
+        'timestamp': datetime.utcnow()
+    }
+
+    try:
+        db.logout_tracking.insert_one(record)
+        return jsonify({'message': 'Logout tracked.'}), 201
+    except Exception as e:
+        logger.error(f"Error recording logout for {user_email}: {e}")
+        return jsonify({'error': 'Failed to track logout.'}), 500
+
+
 @main_routes.route('/api/process_repo', methods=['POST'])
 @cross_origin(origin='*')
 def process_repo():

--- a/tests/test_login_logout_tracking.py
+++ b/tests/test_login_logout_tracking.py
@@ -1,0 +1,53 @@
+import os
+import os
+import os
+from pathlib import Path
+import sys
+from datetime import datetime
+import types
+import mongomock
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+sys.modules['app.pipeline.orchestrator'] = types.SimpleNamespace(run_pipeline=lambda *a, **k: None)
+sys.modules['app.pipeline.run_pex'] = types.SimpleNamespace(run_forecast=lambda *a, **k: None)
+sys.modules['app.pipeline.rust_runner'] = types.SimpleNamespace(run_rust_code=lambda *a, **k: None)
+sys.modules['app.pipeline.update_pex'] = types.SimpleNamespace(update_pex_generator=lambda *a, **k: None)
+
+from app import create_app
+
+
+def setup_mock_db(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client['test-db']
+    monkeypatch.setattr('app.routes.db', mock_db)
+    return mock_db
+
+
+def create_test_client():
+    app = create_app()
+    return app.test_client()
+
+
+def test_track_login_records_event(monkeypatch):
+    mock_db = setup_mock_db(monkeypatch)
+    client = create_test_client()
+
+    res = client.post('/api/track_login', json={'user_email': 'user@example.com'})
+    assert res.status_code == 201
+
+    stored = mock_db.login_tracking.find_one({'user_email': 'user@example.com'})
+    assert stored is not None
+    assert isinstance(stored['timestamp'], datetime)
+
+
+def test_track_logout_records_event(monkeypatch):
+    mock_db = setup_mock_db(monkeypatch)
+    client = create_test_client()
+
+    res = client.post('/api/track_logout', json={'user_email': 'user@example.com'})
+    assert res.status_code == 201
+
+    stored = mock_db.logout_tracking.find_one({'user_email': 'user@example.com'})
+    assert stored is not None
+    assert isinstance(stored['timestamp'], datetime)


### PR DESCRIPTION
## Summary
- add `/api/track_login` to record user login events with timestamps
- add `/api/track_logout` to record user logout events with timestamps
- document new endpoints and provide usage examples
- add tests for login and logout tracking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba7fab618c832aaaf0c07ef913dbab